### PR TITLE
refactor: replace warning-tuple plumbing with docutils' native error idiom

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dev = [
 
 [tool.mypy]
 files = ["src", "tests"]
+exclude = ["tests/fixtures/"]
 
 [tool.ruff]
 lint.select = [

--- a/src/sphinx_kroki/kroki.py
+++ b/src/sphinx_kroki/kroki.py
@@ -116,35 +116,24 @@ class Kroki(SphinxDirective):
         source = "\n".join(self.content)
         filename, diagram_type, output_format = self._parse_arguments()
 
-        filename, warning = self._resolve_filename(filename)
-        if warning is None:
-            source, warning = self._resolve_source(source, filename)
-        if warning is not None:
-            return [warning]
-
+        filename = self._resolve_filename(filename)
+        source = self._resolve_source(source, filename)
         if not source.strip():
-            return [
-                self._warning(
+            raise self.warning(
+                __(
                     "Ignoring kroki directive without content. It is necessary "
                     "to specify filename argument/option or content"
                 )
-            ]
+            )
+        diagram_type = self._resolve_diagram_type(diagram_type, filename)
+        output_format = self._resolve_output_format(output_format)
+        diagram_options = self._load_diagram_options()
 
-        diagram_type, warning = self._resolve_diagram_type(diagram_type, filename)
-        if warning is not None:
-            return [warning]
-
-        output_format, warning = self._resolve_output_format(output_format)
-        if warning is not None:
-            return [warning]
-
-        diagram_options, warning = self._load_diagram_options()
-        if warning is not None:
-            return [warning]
-
-        diagram_type = cast("str", diagram_type)
-        node = self._create_node(diagram_type, source, output_format, diagram_options)
-        return self._wrap_node(node, diagram_type)
+        classes = ["kroki", f"kroki-{diagram_type}"]
+        node = self._create_node(
+            diagram_type, source, output_format, diagram_options, classes
+        )
+        return self._wrap_node(node, classes)
 
     def _parse_arguments(self) -> tuple[str | None, str | None, str | None]:
         filename: str | None = None
@@ -161,104 +150,98 @@ class Kroki(SphinxDirective):
 
         return filename, diagram_type, output_format
 
-    def _resolve_filename(self, filename: str | None) -> tuple[str | None, Node | None]:
-        if "filename" in self.options:
-            if filename is not None:
-                return None, self._warning(
-                    "Kroki directive cannot have both filename option and a "
-                    "filename argument"
-                )
-            filename = cast("str", self.options["filename"])
-        return filename, None
+    def _check_option_argument_conflict(
+        self, name: str, argument: object | None
+    ) -> None:
+        if name in self.options and argument is not None:
+            raise self.warning(
+                __("Kroki directive cannot have both %s option and a %s argument")
+                % (name, name)
+            )
 
-    def _resolve_source(
-        self, source: str, filename: str | None
-    ) -> tuple[str, Node | None]:
+    def _resolve_filename(self, filename: str | None) -> str | None:
+        self._check_option_argument_conflict("filename", filename)
+        if "filename" in self.options:
+            return cast("str", self.options["filename"])
+        return filename
+
+    def _resolve_source(self, source: str, filename: str | None) -> str:
         if source.strip() and filename is not None:
-            return source, self._warning(
-                "Kroki directive cannot have both content and a filename argument"
+            raise self.warning(
+                __("Kroki directive cannot have both content and a filename argument")
             )
 
         if filename is None:
-            return source, None
+            return source
 
         argument = search_image_for_language(filename, self.env)
         rel_filename, resolved_filename = self.env.relfn2path(argument)
         self.env.note_dependency(rel_filename)
         try:
-            return Path(resolved_filename).read_text(encoding="utf-8"), None
-        except OSError:
-            return source, self._warning(
-                "External kroki file %r not found or reading it failed",
-                resolved_filename,
-            )
+            return Path(resolved_filename).read_text(encoding="utf-8")
+        except OSError as exc:
+            raise self.warning(
+                __("External kroki file %r not found or reading it failed")
+                % resolved_filename
+            ) from exc
 
     def _resolve_diagram_type(
         self, diagram_type: str | None, filename: str | None
-    ) -> tuple[str | None, Node | None]:
+    ) -> str:
+        self._check_option_argument_conflict("type", diagram_type)
         if "type" in self.options:
-            if diagram_type is not None:
-                return None, self._warning(
-                    "Kroki directive cannot have both type option and a type argument"
-                )
-            diagram_type = types[cast("str", self.options["type"])]
-        elif diagram_type is None and filename is not None:
+            return types[cast("str", self.options["type"])]
+        if diagram_type is not None:
+            return diagram_type
+        if filename is not None:
             suffix = Path(filename).suffix.lstrip(".")
-            diagram_type = extension_type_map.get(suffix, types.get(suffix))
+            resolved = extension_type_map.get(suffix, types.get(suffix))
+            if resolved is not None:
+                return resolved
+        raise self.warning(__("Kroki directive has to define diagram type."))
 
-        if diagram_type is None:
-            return None, self._warning("Kroki directive has to define diagram type.")
-
-        return diagram_type, None
-
-    def _resolve_output_format(
-        self, output_format: str | None
-    ) -> tuple[str | None, Node | None]:
+    def _resolve_output_format(self, output_format: str | None) -> str:
+        self._check_option_argument_conflict("format", output_format)
         if "format" in self.options:
-            if output_format is not None:
-                return None, self._warning(
-                    "Kroki directive cannot have both format option and a "
-                    "format argument"
-                )
-            output_format = cast("str", self.options["format"])
+            return cast("str", self.options["format"])
+        if output_format is not None:
+            return output_format
+        return cast("str", self.config.kroki_output_format)
 
-        return output_format, None
-
-    def _load_diagram_options(self) -> tuple[dict[str, object] | None, Node | None]:
+    def _load_diagram_options(self) -> dict[str, object] | None:
         if "options" not in self.options:
-            return None, None
+            return None
 
         loaded = yaml.safe_load(cast("str", self.options["options"]))
         if loaded is None:
-            return {}, None
+            return {}
         if not isinstance(loaded, dict):
-            return None, self._warning("Kroki directive options must be a YAML mapping")
-        return cast("dict[str, object]", loaded), None
+            raise self.warning(__("Kroki directive options must be a YAML mapping"))
+        return cast("dict[str, object]", loaded)
 
     def _create_node(
         self,
         diagram_type: str,
         source: str,
-        output_format: str | None,
+        output_format: str,
         diagram_options: dict[str, object] | None,
+        classes: list[str],
     ) -> KrokiNode:
         node = KrokiNode()
         node["type"] = diagram_type
-        if output_format is not None:
-            node["format"] = output_format
+        node["format"] = output_format
         node["source"] = source
 
         if diagram_options is not None:
             node["options"] = diagram_options
 
-        classes = ["kroki", f"kroki-{diagram_type}"]
         node["classes"] = classes + self.options.get("class", [])
         if "align" in self.options:
             node["align"] = self.options["align"]
 
         return node
 
-    def _wrap_node(self, node: KrokiNode, diagram_type: str) -> list[Node]:
+    def _wrap_node(self, node: KrokiNode, classes: list[str]) -> list[Node]:
         if "caption" not in self.options:
             self.add_name(node)
             return [node]
@@ -273,15 +256,9 @@ class Kroki(SphinxDirective):
         caption_node.extend(messages)
         set_source_info(self, caption_node)
         figure += caption_node
-        figure["classes"] = ["kroki", f"kroki-{diagram_type}"]
+        figure["classes"] = list(classes)
         self.add_name(figure)
         return [figure]
-
-    def _warning(self, message: str, *args: object) -> Node:
-        translated = __(message)
-        if args:
-            translated = translated % args
-        return self.state.document.reporter.warning(translated, line=self.lineno)
 
 
 def render_kroki(

--- a/src/sphinx_kroki/transform.py
+++ b/src/sphinx_kroki/transform.py
@@ -42,11 +42,8 @@ class KrokiToImageTransform(SphinxTransform):
 
             node.replace_self(img)
 
-    def _output_format(self, node: KrokiNode) -> str:
-        return cast("str", node.get("format", self._builder.config.kroki_output_format))
-
     def _render(self, node: KrokiNode, prefix: str = "kroki") -> Path:
-        output_format = self._output_format(node)
+        output_format = cast("str", node["format"])
         diagram_type = cast("str", node["type"])
         diagram_source = cast("str", node["source"])
 

--- a/tests/fixtures/test-kroki-warnings/conf.py
+++ b/tests/fixtures/test-kroki-warnings/conf.py
@@ -1,0 +1,2 @@
+extensions = ["sphinx_kroki"]
+exclude_patterns = ["_build"]

--- a/tests/fixtures/test-kroki-warnings/index.rst
+++ b/tests/fixtures/test-kroki-warnings/index.rst
@@ -1,0 +1,35 @@
+kroki warnings
+==============
+
+.. kroki:: diagram.puml
+   :filename: diagram.puml
+
+.. kroki:: plantuml
+   :type: plantuml
+
+   foo -> bar
+
+.. kroki:: svg
+   :type: plantuml
+   :format: svg
+
+   foo -> bar
+
+.. kroki:: diagram.puml
+
+   foo -> bar
+
+.. kroki::
+
+   foo -> bar
+
+.. kroki::
+   :type: plantuml
+
+.. kroki::
+   :type: plantuml
+   :options: [not, a, mapping]
+
+   foo -> bar
+
+.. kroki:: missing.puml

--- a/tests/test_kroki.py
+++ b/tests/test_kroki.py
@@ -10,6 +10,7 @@ import pytest
 import requests
 import sphinx
 from sphinx.application import Sphinx
+from sphinx.testing.util import SphinxTestApp
 
 from sphinx_kroki import kroki as kroki_module
 
@@ -22,8 +23,9 @@ def get_content(app: Sphinx) -> str:
 
 
 @pytest.mark.sphinx("html", testroot="kroki", confoverrides={"master_doc": "index"})
-def test_kroki_html(app: Sphinx) -> None:
+def test_kroki_html(app: SphinxTestApp) -> None:
     content = get_content(app)
+    assert app.warning.getvalue() == ""
     html = (
         r'figure[^>]*?(?:kroki kroki-plantuml align-default)?" .*?>\s*'
         r'<img alt="bar -&gt; baz" class="kroki kroki-plantuml" .+?/>.*?'
@@ -55,6 +57,30 @@ def test_kroki_html(app: Sphinx) -> None:
     else:
         html = r'<img.*?class="kroki kroki-ditaa align-right".*?/>'
     assert re.search(html, content, re.DOTALL)
+
+
+@pytest.mark.sphinx(
+    "html", testroot="kroki-warnings", confoverrides={"master_doc": "index"}
+)
+def test_kroki_invalid_directives_warn_and_suppress_output(app: SphinxTestApp) -> None:
+    content = get_content(app)
+    warnings = app.warning.getvalue()
+
+    expected = (
+        "Kroki directive cannot have both filename option and a filename argument",
+        "Kroki directive cannot have both type option and a type argument",
+        "Kroki directive cannot have both format option and a format argument",
+        "Kroki directive cannot have both content and a filename argument",
+        "Kroki directive has to define diagram type.",
+        "Ignoring kroki directive without content",
+        "Kroki directive options must be a YAML mapping",
+        "not found or reading it failed",
+    )
+    for message in expected:
+        assert message in warnings
+    assert warnings.count("WARNING") == len(expected)
+    assert "index.rst:4: " in warnings
+    assert "<img" not in content
 
 
 def test_render_kroki_cleans_up_partial_files(


### PR DESCRIPTION
The Kroki directive threaded tuple[value, Node | None] pairs through
run() and five _resolve_* helpers, with a repeated
"if warning is not None: return [warning]" guard after nearly every
call — a hand-rolled reimplementation of error handling that docutils
directives already provide. Raising self.warning(...) inside run()
produces the same warning-level system message at the same directive
line, so the entire bespoke channel is removed:

- delete the custom _warning() helper and every Optional-tuple return
  type; each resolver now returns a plain value and raises on failure
- collapse the three near-identical "cannot have both X option and X
  argument" checks into one shared helper
- build the ["kroki", "kroki-<type>"] class list once instead of twice
- resolve the kroki_output_format config default in the directive
  (safe: the value is registered with rebuild="env"), so KrokiNode
  always carries a concrete format and the transform's _output_format
  shim is deleted

Adds a test fixture and test pinning every previously untested
validation branch (option/argument conflicts, missing type, empty
content, non-mapping YAML options, unreadable external file), asserts
the happy-path build is warning-free, and excludes test fixtures from
mypy (the second fixture conf.py would otherwise collide as a
duplicate module).

Behavior notes: the consolidated conflict message interpolates the
option name, so its wording differs trivially from the three old
literals; with keep_warnings=True, docutils now appends the directive
block text to the emitted system message.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DpY11Kvxri1oFW1vfj4uB2